### PR TITLE
#16 [Feat] 프로필 화면 레이아웃 작업

### DIFF
--- a/Profile_FE/profile.py
+++ b/Profile_FE/profile.py
@@ -1,22 +1,34 @@
 import streamlit as st
 import json
-import logging
-import sys
 import os
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
-#db 연결
-#from Python_Script_Profile.insert_to_db import send_data_to_server, combine_data_for_db  
-# 로깅 설정
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+
+# JSON 파일 경로
+JSON_FILE = "user_data.json"
+
+# JSON 파일 읽기
+def read_json():
+    if not os.path.exists(JSON_FILE):
+        return {"users": []}  # 파일이 없으면 기본 구조 반환
+    with open(JSON_FILE, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+# JSON 파일 쓰기
+def write_json(data):
+    with open(JSON_FILE, "w", encoding="utf-8") as file:
+        json.dump(data, file, ensure_ascii=False, indent=4)
 
 # 초기화 함수
 def initialize_state(user_data):
     if "self_intro" not in st.session_state:
-        st.session_state.self_intro = ""
+        data = read_json()
+        user_profile = next((user["profile"] for user in data["users"] if user["name"] == user_data["name"]), {})
+        st.session_state.self_intro = user_profile.get("self_intro", "")
     if "selected_skills" not in st.session_state:
-        st.session_state.selected_skills = []
+        st.session_state.selected_skills = user_profile.get("skills", [])
     if "user_data" not in st.session_state:
-        st.session_state.user_data = user_data  # 사용자 데이터 저장
+        st.session_state.user_data = user_data
+    if "page" not in st.session_state:
+        st.session_state.page = "display"
 
 # 기술 스택 이미지 URL 정의
 def get_skills():
@@ -28,26 +40,44 @@ def get_skills():
         "Adobe Illustrator": "https://img.shields.io/badge/adobeillustrator-FF9A00?style=flat-square&logo=adobeillustrator&logoColor=black",
     }
 
-# 상태 저장 함수
-def save_changes():
-    st.session_state.page = "display"
-    st.session_state.self_intro = st.session_state.self_intro
-    #json_data = json.dumps(combine_data_for_db(get_skills(), st.session_state), ensure_ascii=False, indent=4)
-    # logging.info("저장된 정보: %s", json_data)
-    #send_data_to_server(combine_data_for_db(get_skills(), st.session_state))  # 서버로 데이터 전송
-    st.success("정보가 저장되었습니다.")
+# 로그아웃 함수
+def logout():
+    st.session_state.clear()
+    st.session_state.current_page = "login"
+
+# 데이터 저장 함수
+def save_user_data(user_data):
+    data = read_json()  # 기존 데이터 불러오기
+    # 사용자 이름에 해당하는 기존 데이터를 찾아 수정
+    for user in data["users"]:
+        if user["name"] == user_data["name"]:
+            user["profile"] = {
+                "self_intro": st.session_state.self_intro,
+                "skills": st.session_state.selected_skills,
+            }
+            break
+    else:
+        # 신규 사용자일 경우 추가
+        data["users"].append({
+            "name": user_data["name"],
+            "password": user_data["password"],
+            "profile": {
+                "self_intro": st.session_state.self_intro,
+                "skills": st.session_state.selected_skills,
+            }
+        })
+    write_json(data)  # 업데이트된 데이터를 JSON 파일에 저장
 
 # 입력 페이지 렌더링
 def render_input_page(skills):
+    st.sidebar.button("로그아웃", on_click=logout)
     st.title("내 정보 등록")
     user_data = st.session_state.user_data
     st.text_input("이름", value=user_data.get("name", ""), disabled=True)
     st.text_input("비밀번호", value=user_data.get("password", ""), type="password", disabled=True)
 
     # 자기소개 입력
-    self_intro_input = st.text_area(
-        "자기소개", value=st.session_state.self_intro, placeholder="자기소개를 입력하세요"
-    )
+    self_intro_input = st.text_area("자기소개", value=st.session_state.self_intro, placeholder="자기소개를 입력하세요")
     st.session_state.self_intro = self_intro_input
 
     # 기술 선택
@@ -57,24 +87,28 @@ def render_input_page(skills):
     ]
 
     if st.button("저장하기"):
-        if not st.session_state.self_intro.strip():  # 자기소개가 비어 있는 경우
+        if not st.session_state.self_intro.strip():
             st.warning("자기소개를 입력해주세요!")
         else:
-            save_changes()
+            save_user_data(st.session_state.user_data)
+            st.session_state.page = "display"
+            st.success("정보가 저장되었습니다.")
 
 # 출력 페이지 렌더링
 def render_display_page(skills):
+    st.sidebar.button("로그아웃", on_click=logout)
     st.title("내 정보")
     user_data = st.session_state.user_data
+
     st.text_input("이름", value=user_data.get("name", ""), disabled=True)
     st.text_input("비밀번호", value=user_data.get("password", ""), type="password", disabled=True)
     st.text_area("자기소개", value=st.session_state.self_intro, disabled=True)
 
     # 선택한 기술 출력
     if st.session_state.selected_skills:
-        st.write("**사용 가능한 기술:**")
+        st.markdown("#### 사용 가능한 기술")
         for skill in st.session_state.selected_skills:
-            st.image(skills[skill], width=50)
+            st.image(skills.get(skill, ""), width=50)
 
     if st.button("내 정보 수정"):
         st.session_state.page = "input"
@@ -84,9 +118,7 @@ def main(user_data):
     initialize_state(user_data)
     skills = get_skills()
 
-    if st.session_state.get("page", "input") == "input":
+    if st.session_state.page == "input":
         render_input_page(skills)
     elif st.session_state.page == "display":
         render_display_page(skills)
-    #서버 전송
-    # send_data_to_server(combine_data_for_db(skills, st.session_state))

--- a/Profile_FE/profile.py
+++ b/Profile_FE/profile.py
@@ -1,74 +1,103 @@
 import streamlit as st
+import json
+import logging
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
+from Python_Script_Profile.insert_to_db import send_data_to_server, combine_data_for_db
 
-# 초기 페이지 설정
-if "page" not in st.session_state:
-    st.session_state.page = "input"
+# 로깅 설정
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
 
-# 초기 데이터 설정
-if "name" not in st.session_state:
-    st.session_state.name = ""
-if "self_intro" not in st.session_state:
-    st.session_state.self_intro = ""
-if "selected_skills" not in st.session_state:
-    st.session_state.selected_skills = []
+# 초기 상태 설정
+def initialize_state():
+    if "page" not in st.session_state:
+        st.session_state.page = "input"
+    if "name" not in st.session_state:
+        st.session_state.name = ""
+    if "self_intro" not in st.session_state:
+        st.session_state.self_intro = ""
+    if "selected_skills" not in st.session_state:
+        st.session_state.selected_skills = []
 
-# 기술 이미지 URL 정의 (전역 변수로 설정)
-skills = {
-    "Java": "https://img.shields.io/badge/Java-007396?style=flat-square&logo=Java&logoColor=white",
-    "C": "https://img.shields.io/badge/C-A8B9CC?style=flat-square&logo=C&logoColor=white",
-    "Python": "https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=Python&logoColor=white",
-    "Spring": "https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=Spring&logoColor=white",
-    "Adobe Illustrator": "https://img.shields.io/badge/adobeillustrator-FF9A00?style=flat-square&logo=adobeillustrator&logoColor=black",
-}
-##E34F26
-# 입력 페이지
-if st.session_state.page == "input":
+# skill 이미지 URL 정의
+def get_skills():
+    return {
+        "Java": "https://img.shields.io/badge/Java-007396?style=flat-square&logo=Java&logoColor=white",
+        "C": "https://img.shields.io/badge/C-A8B9CC?style=flat-square&logo=C&logoColor=white",
+        "Python": "https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=Python&logoColor=white",
+        "Spring": "https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=Spring&logoColor=white",
+        "Adobe Illustrator": "https://img.shields.io/badge/adobeillustrator-FF9A00?style=flat-square&logo=adobeillustrator&logoColor=black",
+    }
+
+# 상태 저장 함수
+def save_changes():
+    st.session_state.page = "display"
+    json_data = json.dumps(combine_data_for_db(get_skills(), st.session_state), ensure_ascii=False, indent=4)
+    logging.info("저장된 정보: %s", json_data)
+    st.success("정보가 저장되었습니다.")
+
+# 입력 페이지 렌더링
+def render_input_page(skills):
     st.title("내 정보 등록")
 
-    # 이름 입력 필드
-    st.session_state.name = st.text_input(
-        "이름", value=st.session_state.name, placeholder="이름을 입력하세요"
+    # 이름 입력
+    name = st.text_input(
+        "이름",
+        value=st.session_state.name,
+        placeholder="이름을 입력하세요",
+    )
+    
+    # 자기소개 입력
+    self_intro = st.text_area(
+        "자기소개",
+        value=st.session_state.self_intro,
+        placeholder="자기소개를 입력하세요",
     )
 
-    # 자기소개 입력 필드
-    self_intro_input = st.text_area(
-        "자기소개", value=st.session_state.self_intro, placeholder="자기소개를 입력하세요"
-    )
-    if st.button("자기소개 저장"):
-        st.session_state.self_intro = self_intro_input  # 자기소개를 저장
-        st.success("자기소개가 저장되었습니다!")
-
-    # 기술 선택
+    # skill 선택
     st.markdown("#### 사용 가능한 기술")
     selected_skills = []
     for skill in skills.keys():
         if st.checkbox(skill, key=skill, value=(skill in st.session_state.selected_skills)):
             selected_skills.append(skill)
 
-    if st.button("스택 추가"):
-        st.session_state.selected_skills = selected_skills
-        st.success("기술 스택이 저장되었습니다!")
-
-    # "프로필 저장" 버튼
+    # 저장 버튼
     if st.button("저장하기"):
-        st.session_state.page = "display"
+        st.session_state.name = name
+        st.session_state.self_intro = self_intro
+        st.session_state.selected_skills = selected_skills
+        save_changes()
 
-# 출력 페이지
-elif st.session_state.page == "display":
+# 출력 페이지 렌더링
+def render_display_page(skills):
     st.title("내 정보")
 
-    # 이름을 수정 불가능한 텍스트 박스에 표시
+    # 이름과 자기소개 표시
     st.text_input("이름", value=st.session_state.name, disabled=True)
-
-    # 자기소개를 수정 불가능한 텍스트 박스에 표시
     st.text_area("자기소개", value=st.session_state.self_intro, disabled=True)
 
-    # 기술 출력
+    # skill 출력
     if st.session_state.selected_skills:
         st.write("**사용 가능한 기술:**")
         for skill in st.session_state.selected_skills:
             st.image(skills[skill], width=50)
 
-    # "수정 페이지로 이동" 버튼
+    # 수정 버튼
     if st.button("내 정보 수정"):
         st.session_state.page = "input"
+
+# 메인 함수
+def main():
+    initialize_state()
+    skills = get_skills()
+    if st.session_state.page == "input":
+        render_input_page(skills)
+    elif st.session_state.page == "display":
+        render_display_page(skills)
+        # 데이터가 저장되면 서버로 전송
+        send_data_to_server(combine_data_for_db(skills, st.session_state))
+
+# Streamlit 실행
+if __name__ == "__main__":
+    main()

--- a/Profile_FE/profile.py
+++ b/Profile_FE/profile.py
@@ -1,4 +1,13 @@
 import streamlit as st
+import json
+import logging
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
+#db 연결
+#from Python_Script_Profile.insert_to_db import send_data_to_server, combine_data_for_db  
+# 로깅 설정
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
 
 # 초기화 함수
 def initialize_state(user_data):
@@ -23,6 +32,9 @@ def get_skills():
 def save_changes():
     st.session_state.page = "display"
     st.session_state.self_intro = st.session_state.self_intro
+    #json_data = json.dumps(combine_data_for_db(get_skills(), st.session_state), ensure_ascii=False, indent=4)
+    # logging.info("저장된 정보: %s", json_data)
+    #send_data_to_server(combine_data_for_db(get_skills(), st.session_state))  # 서버로 데이터 전송
     st.success("정보가 저장되었습니다.")
 
 # 입력 페이지 렌더링
@@ -76,3 +88,5 @@ def main(user_data):
         render_input_page(skills)
     elif st.session_state.page == "display":
         render_display_page(skills)
+    #서버 전송
+    # send_data_to_server(combine_data_for_db(skills, st.session_state))

--- a/Profile_FE/profile.py
+++ b/Profile_FE/profile.py
@@ -4,17 +4,22 @@ import logging
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
-from Python_Script_Profile.insert_to_db import send_data_to_server, combine_data_for_db
+#rom Python_Script_Profile.insert_to_db import send_data_to_server, combine_data_for_db 
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
-
-# 초기 상태 설정
 def initialize_state():
+    #페이지 설정
     if "page" not in st.session_state:
         st.session_state.page = "input"
+    
     if "name" not in st.session_state:
-        st.session_state.name = ""
+        st.session_state.name = "양화영"
+        #st.session_state.name = get_user_name_from_db()  #DB에서 이름 가져오기
+
+    if "password" not in st.session_state:
+        st.session_state.password = "1234"  # 초기 비밀번호 설정
+    #st.session_state.password = get_user_password_from_db()
     if "self_intro" not in st.session_state:
         st.session_state.self_intro = ""
     if "selected_skills" not in st.session_state:
@@ -29,61 +34,52 @@ def get_skills():
         "Spring": "https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=Spring&logoColor=white",
         "Adobe Illustrator": "https://img.shields.io/badge/adobeillustrator-FF9A00?style=flat-square&logo=adobeillustrator&logoColor=black",
     }
-
-# 상태 저장 함수
+   # 상태 저장 함수
 def save_changes():
     st.session_state.page = "display"
-    json_data = json.dumps(combine_data_for_db(get_skills(), st.session_state), ensure_ascii=False, indent=4)
-    logging.info("저장된 정보: %s", json_data)
+    st.session_state.self_intro = st.session_state.self_intro
+    #json_data = json.dumps(combine_data_for_db(get_skills(), st.session_state), ensure_ascii=False, indent=4)
+   # logging.info("저장된 정보: %s", json_data)
+    #send_data_to_server(combine_data_for_db(get_skills(), st.session_state))  # 서버로 데이터 전송
     st.success("정보가 저장되었습니다.")
 
-# 입력 페이지 렌더링
+# 입력 페이지
 def render_input_page(skills):
     st.title("내 정보 등록")
+    st.text_input("이름", value=st.session_state.name, disabled=True)
+    st.text_input("비밀번호", value=st.session_state.password, type="password", disabled=True)
 
-    # 이름 입력
-    name = st.text_input(
-        "이름",
-        value=st.session_state.name,
-        placeholder="이름을 입력하세요",
+    # 자기소개 입력 필드
+    self_intro_input = st.text_area(
+        "자기소개", value=st.session_state.self_intro, placeholder="자기소개를 입력하세요"
     )
-    
-    # 자기소개 입력
-    self_intro = st.text_area(
-        "자기소개",
-        value=st.session_state.self_intro,
-        placeholder="자기소개를 입력하세요",
-    )
+    st.session_state.self_intro = self_intro_input
 
-    # skill 선택
+    # 스택 선택
     st.markdown("#### 사용 가능한 기술")
-    selected_skills = []
-    for skill in skills.keys():
-        if st.checkbox(skill, key=skill, value=(skill in st.session_state.selected_skills)):
-            selected_skills.append(skill)
+    st.session_state.selected_skills = [
+        skill for skill in skills.keys() if st.checkbox(skill, key=skill, value=(skill in st.session_state.selected_skills))
+    ]
 
-    # 저장 버튼
     if st.button("저장하기"):
-        st.session_state.name = name
-        st.session_state.self_intro = self_intro
-        st.session_state.selected_skills = selected_skills
-        save_changes()
+        if not st.session_state.self_intro.strip():  # 자기소개가 공백 또는 비어 있는 경우
+            st.warning("자기소개를 입력해주세요!")
+        else:
+            save_changes()
 
-# 출력 페이지 렌더링
+# 출력 페이지
 def render_display_page(skills):
     st.title("내 정보")
-
-    # 이름과 자기소개 표시
     st.text_input("이름", value=st.session_state.name, disabled=True)
+    st.text_input("비밀번호", value=st.session_state.password, type="password", disabled=True)
     st.text_area("자기소개", value=st.session_state.self_intro, disabled=True)
 
-    # skill 출력
+    # 기술 출력
     if st.session_state.selected_skills:
         st.write("**사용 가능한 기술:**")
         for skill in st.session_state.selected_skills:
             st.image(skills[skill], width=50)
 
-    # 수정 버튼
     if st.button("내 정보 수정"):
         st.session_state.page = "input"
 
@@ -96,7 +92,7 @@ def main():
     elif st.session_state.page == "display":
         render_display_page(skills)
         # 데이터가 저장되면 서버로 전송
-        send_data_to_server(combine_data_for_db(skills, st.session_state))
+       # send_data_to_server(combine_data_for_db(skills, st.session_state))
 
 # Streamlit 실행
 if __name__ == "__main__":

--- a/Profile_FE/profile.py
+++ b/Profile_FE/profile.py
@@ -1,31 +1,15 @@
 import streamlit as st
-import json
-import logging
-import sys
-import os
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
-#rom Python_Script_Profile.insert_to_db import send_data_to_server, combine_data_for_db 
 
-# 로깅 설정
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
-def initialize_state():
-    #페이지 설정
-    if "page" not in st.session_state:
-        st.session_state.page = "input"
-    
-    if "name" not in st.session_state:
-        st.session_state.name = "양화영"
-        #st.session_state.name = get_user_name_from_db()  #DB에서 이름 가져오기
-
-    if "password" not in st.session_state:
-        st.session_state.password = "1234"  # 초기 비밀번호 설정
-    #st.session_state.password = get_user_password_from_db()
+# 초기화 함수
+def initialize_state(user_data):
     if "self_intro" not in st.session_state:
         st.session_state.self_intro = ""
     if "selected_skills" not in st.session_state:
         st.session_state.selected_skills = []
+    if "user_data" not in st.session_state:
+        st.session_state.user_data = user_data  # 사용자 데이터 저장
 
-# skill 이미지 URL 정의
+# 기술 스택 이미지 URL 정의
 def get_skills():
     return {
         "Java": "https://img.shields.io/badge/Java-007396?style=flat-square&logo=Java&logoColor=white",
@@ -34,47 +18,47 @@ def get_skills():
         "Spring": "https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=Spring&logoColor=white",
         "Adobe Illustrator": "https://img.shields.io/badge/adobeillustrator-FF9A00?style=flat-square&logo=adobeillustrator&logoColor=black",
     }
-   # 상태 저장 함수
+
+# 상태 저장 함수
 def save_changes():
     st.session_state.page = "display"
     st.session_state.self_intro = st.session_state.self_intro
-    #json_data = json.dumps(combine_data_for_db(get_skills(), st.session_state), ensure_ascii=False, indent=4)
-   # logging.info("저장된 정보: %s", json_data)
-    #send_data_to_server(combine_data_for_db(get_skills(), st.session_state))  # 서버로 데이터 전송
     st.success("정보가 저장되었습니다.")
 
-# 입력 페이지
+# 입력 페이지 렌더링
 def render_input_page(skills):
     st.title("내 정보 등록")
-    st.text_input("이름", value=st.session_state.name, disabled=True)
-    st.text_input("비밀번호", value=st.session_state.password, type="password", disabled=True)
+    user_data = st.session_state.user_data
+    st.text_input("이름", value=user_data.get("name", ""), disabled=True)
+    st.text_input("비밀번호", value=user_data.get("password", ""), type="password", disabled=True)
 
-    # 자기소개 입력 필드
+    # 자기소개 입력
     self_intro_input = st.text_area(
         "자기소개", value=st.session_state.self_intro, placeholder="자기소개를 입력하세요"
     )
     st.session_state.self_intro = self_intro_input
 
-    # 스택 선택
+    # 기술 선택
     st.markdown("#### 사용 가능한 기술")
     st.session_state.selected_skills = [
         skill for skill in skills.keys() if st.checkbox(skill, key=skill, value=(skill in st.session_state.selected_skills))
     ]
 
     if st.button("저장하기"):
-        if not st.session_state.self_intro.strip():  # 자기소개가 공백 또는 비어 있는 경우
+        if not st.session_state.self_intro.strip():  # 자기소개가 비어 있는 경우
             st.warning("자기소개를 입력해주세요!")
         else:
             save_changes()
 
-# 출력 페이지
+# 출력 페이지 렌더링
 def render_display_page(skills):
     st.title("내 정보")
-    st.text_input("이름", value=st.session_state.name, disabled=True)
-    st.text_input("비밀번호", value=st.session_state.password, type="password", disabled=True)
+    user_data = st.session_state.user_data
+    st.text_input("이름", value=user_data.get("name", ""), disabled=True)
+    st.text_input("비밀번호", value=user_data.get("password", ""), type="password", disabled=True)
     st.text_area("자기소개", value=st.session_state.self_intro, disabled=True)
 
-    # 기술 출력
+    # 선택한 기술 출력
     if st.session_state.selected_skills:
         st.write("**사용 가능한 기술:**")
         for skill in st.session_state.selected_skills:
@@ -84,16 +68,11 @@ def render_display_page(skills):
         st.session_state.page = "input"
 
 # 메인 함수
-def main():
-    initialize_state()
+def main(user_data):
+    initialize_state(user_data)
     skills = get_skills()
-    if st.session_state.page == "input":
+
+    if st.session_state.get("page", "input") == "input":
         render_input_page(skills)
     elif st.session_state.page == "display":
         render_display_page(skills)
-        # 데이터가 저장되면 서버로 전송
-       # send_data_to_server(combine_data_for_db(skills, st.session_state))
-
-# Streamlit 실행
-if __name__ == "__main__":
-    main()

--- a/Profile_FE/profile.py
+++ b/Profile_FE/profile.py
@@ -1,0 +1,74 @@
+import streamlit as st
+
+# 초기 페이지 설정
+if "page" not in st.session_state:
+    st.session_state.page = "input"
+
+# 초기 데이터 설정
+if "name" not in st.session_state:
+    st.session_state.name = ""
+if "self_intro" not in st.session_state:
+    st.session_state.self_intro = ""
+if "selected_skills" not in st.session_state:
+    st.session_state.selected_skills = []
+
+# 기술 이미지 URL 정의 (전역 변수로 설정)
+skills = {
+    "Java": "https://img.shields.io/badge/Java-007396?style=flat-square&logo=Java&logoColor=white",
+    "C": "https://img.shields.io/badge/C-A8B9CC?style=flat-square&logo=C&logoColor=white",
+    "Python": "https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=Python&logoColor=white",
+    "Spring": "https://img.shields.io/badge/Spring-6DB33F?style=flat-square&logo=Spring&logoColor=white",
+    "Adobe Illustrator": "https://img.shields.io/badge/adobeillustrator-FF9A00?style=flat-square&logo=adobeillustrator&logoColor=black",
+}
+##E34F26
+# 입력 페이지
+if st.session_state.page == "input":
+    st.title("내 정보 등록")
+
+    # 이름 입력 필드
+    st.session_state.name = st.text_input(
+        "이름", value=st.session_state.name, placeholder="이름을 입력하세요"
+    )
+
+    # 자기소개 입력 필드
+    self_intro_input = st.text_area(
+        "자기소개", value=st.session_state.self_intro, placeholder="자기소개를 입력하세요"
+    )
+    if st.button("자기소개 저장"):
+        st.session_state.self_intro = self_intro_input  # 자기소개를 저장
+        st.success("자기소개가 저장되었습니다!")
+
+    # 기술 선택
+    st.markdown("#### 사용 가능한 기술")
+    selected_skills = []
+    for skill in skills.keys():
+        if st.checkbox(skill, key=skill, value=(skill in st.session_state.selected_skills)):
+            selected_skills.append(skill)
+
+    if st.button("스택 추가"):
+        st.session_state.selected_skills = selected_skills
+        st.success("기술 스택이 저장되었습니다!")
+
+    # "프로필 저장" 버튼
+    if st.button("저장하기"):
+        st.session_state.page = "display"
+
+# 출력 페이지
+elif st.session_state.page == "display":
+    st.title("내 정보")
+
+    # 이름을 수정 불가능한 텍스트 박스에 표시
+    st.text_input("이름", value=st.session_state.name, disabled=True)
+
+    # 자기소개를 수정 불가능한 텍스트 박스에 표시
+    st.text_area("자기소개", value=st.session_state.self_intro, disabled=True)
+
+    # 기술 출력
+    if st.session_state.selected_skills:
+        st.write("**사용 가능한 기술:**")
+        for skill in st.session_state.selected_skills:
+            st.image(skills[skill], width=50)
+
+    # "수정 페이지로 이동" 버튼
+    if st.button("내 정보 수정"):
+        st.session_state.page = "input"


### PR DESCRIPTION
### 작업 내용
- [x] 프로필  화면 구조도 작업 
Figma Link
🔗 https://www.figma.com/design/eZkcWC0bAFf4NvREuonuOi/Untitled?node-id=88-710&t=jMdSdO6fE3N0M4b7-1
- [x] 프로필 화면 기능 구성
- 이름 추가
- 자기 소개
- 스택 추가
   - 스택 별 카테고리 나누기
- [x] 프로필 화면 구현
- [ ] 프로필 화면 스타일 반영 및 테스팅 
- 1차 테스팅 과정에서 수정하면 좋을 부분 : 저장하기 버튼을 누르고 리다이렉트 속도가 느림, 벳지 부분 크기가 재각각(스타일 반영과정에서 통일해야함)
### 구현 결과
사용자 등록에서 저장한 아이디와 비번값을 가지고 와, 프로필 화면에 띄움<br>
해당값은 수정 불가인 Default 값으로 두었음<br>
<img width="1908" alt="스크린샷 2024-12-06 19 51 16" src="https://github.com/user-attachments/assets/1c910f9c-5e9f-4afb-a3e2-7adab42db7c1">
자기소개 미 입력시 경고창 -> 자기소개 입력 및 스택 추가 저장 후 저장된 페이지로 리다이렉트 <br>
<img width="1908" alt="스크린샷 2024-12-06 19 52 29" src="https://github.com/user-attachments/assets/6ccfa1dd-d3fb-4ca0-95a6-8e3dee67955b">
<img width="1908" alt="스크린샷 2024-12-06 19 52 57" src="https://github.com/user-attachments/assets/150b7026-3d5d-4ada-831d-f1fb3b36755f">
수정시 기존의 값 유지 <br>
<img width="1908" alt="스크린샷 2024-12-06 19 53 41" src="https://github.com/user-attachments/assets/8c0de0ff-4e64-4fdf-a9a0-c4b498e7d383">


