### PR TITLE
#31 [Feat] 관리자 대쉬보드 페이지 프론트 개발 및 백엔드 연동

### DIFF
--- a/Front/manage/manage.py
+++ b/Front/manage/manage.py
@@ -1,0 +1,205 @@
+import streamlit as st
+import requests
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../..")
+from Python_Script.select_from_db import get_mysql_data
+from Python_Script_Manage.select_from_db import get_user_data
+
+# 데이터 수정
+def edit_entry(data, entry_id, updated_entry):
+    for i, item in enumerate(data):
+        if item["id"] == entry_id:
+            data[i] = updated_entry
+            break
+    return data
+
+def page_1():
+    if "page" not in st.session_state:
+        st.session_state["page"] = "list"  # 기본 페이지는 리스트
+
+    # 현재 데이터베이스의 공모전 JSON 데이터를 로드
+    data = get_mysql_data()
+
+   # 목록 페이지
+    if st.session_state["page"] == "list":
+        st.title("공모전 관리 (" + str(len(data)) + ")")
+
+        # 데이터 출력
+        for entry in data:
+            col1, col2, col3 = st.columns([1, 8, 2])
+            with col1:
+                st.write(entry["id"])
+            with col2:
+                st.write(entry["title"])
+            with col3:
+                edit_btn = st.button("수정", key=f"edit-{entry['id']}")
+
+                if edit_btn:
+                    st.session_state["edit_id"] = entry["id"]
+                    st.session_state["page"] = "edit"
+                    st.rerun()
+
+    # 수정 페이지
+    elif st.session_state["page"] == "edit":
+        st.title("게시판 수정")
+
+        # 수정할 데이터 가져오기
+        edit_id = st.session_state.get("edit_id")
+        entry_to_edit = next((item for item in data if item["id"] == edit_id), None)
+
+        if entry_to_edit:
+            # 수정 폼
+            updated_title = st.text_input("제목", value=entry_to_edit["title"])
+            updated_date = st.text_input("날짜", value=entry_to_edit["date"])
+            updated_image = st.text_input("이미지 URL", value=entry_to_edit["image"])
+
+            col1, col2, col3, col4 = st.columns([1,1,1,7])
+            # 저장 버튼
+            with col1:
+                if st.button("저장"):
+                    updated_entry = {
+                        "id": edit_id,
+                        "title": updated_title,
+                        "date": updated_date,
+                        "image": updated_image,
+                    }
+                    data = edit_entry(data, edit_id, updated_entry)
+
+                    # 요청을 보낼 URL
+                    url = "http://opsw4.dothome.co.kr/update_crawl_data.php"
+                    response = requests.get(url, params=updated_entry)
+
+                    # 응답 출력
+                    if response.status_code == 200:
+                        print("응답 성공:", response.text)
+                    else:
+                        print("요청 실패:", response.status_code)
+
+                    st.session_state["page"] = "list"
+                    st.rerun()
+            with col2:
+                # 삭제 버튼
+                if st.button("삭제"):
+                    # 요청을 보낼 URL
+                    url = "http://opsw4.dothome.co.kr/delete_crawl_data.php"
+                    response = requests.get(url, params={"id": edit_id})
+
+                    # 응답 출력
+                    if response.status_code == 200:
+                        print("응답 성공:", response.text)
+                    else:
+                        print("요청 실패:", response.status_code)
+
+                    st.session_state["page"] = "list"
+                    st.rerun()
+            with col3: 
+                # 취소 버튼
+                if st.button("취소"):
+                    st.session_state["page"] = "list"
+                    st.rerun()
+            with col4:
+                pass
+        else:
+            st.error("수정할 항목을 찾을 수 없습니다.")
+            if st.button("목록으로 돌아가기"):
+                st.session_state["page"] = "list"
+                st.rerun()
+
+
+def page_2():
+    if "page" not in st.session_state:
+        st.session_state["page"] = "list"  # 기본 페이지는 리스트
+
+    # 현재 데이터베이스의 유저 JSON 데이터를 로드
+    data = get_user_data()
+
+   # 목록 페이지
+    if st.session_state["page"] == "list":
+        st.title("유저 정보 관리 (" + str(len(data)) + ")")
+
+        # 데이터 출력
+        for entry in data:
+            col1, col2, col3 = st.columns([1, 8, 2])
+            with col1:
+                st.write(entry["id"])
+            with col2:
+                st.write(entry["name"])
+            with col3:
+                edit_btn = st.button("수정", key=f"edit-{entry['id']}")
+
+                if edit_btn:
+                    st.session_state["edit_id"] = entry["id"]
+                    st.session_state["page"] = "edit"
+                    st.rerun()
+    
+    # 수정 페이지
+    elif st.session_state["page"] == "edit":
+        st.title("게시판 수정")
+
+        # 수정할 데이터 가져오기
+        edit_id = st.session_state.get("edit_id")
+        entry_to_edit = next((item for item in data if item["id"] == edit_id), None)
+
+        if entry_to_edit:
+            # 수정 폼
+            updated_name = st.text_input("이름", value=entry_to_edit["name"])
+            updated_bio = st.text_input("bio", value=entry_to_edit["bio"])
+            updated_tool = st.text_input("tool", value=entry_to_edit["tool"])
+
+            col1, col2, col3, col4 = st.columns([1,1,1,7])
+            # 저장 버튼
+            with col1:
+                if st.button("저장"):
+                    updated_entry = {
+                        "id": edit_id,
+                        "name": updated_name,
+                        "bio": updated_bio,
+                        "tool": updated_tool,
+                    }
+                    data = edit_entry(data, edit_id, updated_entry)
+
+                    # 요청을 보낼 URL
+                    url = "http://opsw4.dothome.co.kr/update_user_data_manage.php"
+                    response = requests.get(url, params=updated_entry)
+
+                    # 응답 출력
+                    if response.status_code == 200:
+                        print("응답 성공:", response.text)
+                    else:
+                        print("요청 실패:", response.status_code)
+
+                    st.session_state["page"] = "list"
+                    st.rerun()
+            with col2:
+                # 삭제 버튼
+                if st.button("삭제"):
+                    # 요청을 보낼 URL
+                    url = "http://opsw4.dothome.co.kr/delete_user_data_manage.php"
+                    response = requests.get(url, params={"id": edit_id})
+
+                    # 응답 출력
+                    if response.status_code == 200:
+                        print("응답 성공:", response.text)
+                    else:
+                        print("요청 실패:", response.status_code)
+
+                    st.session_state["page"] = "list"
+                    st.rerun()
+            with col3: 
+                # 취소 버튼
+                if st.button("취소"):
+                    st.session_state["page"] = "list"
+                    st.rerun()
+            with col4:
+                pass
+        else:
+            st.error("수정할 항목을 찾을 수 없습니다.")
+            if st.button("목록으로 돌아가기"):
+                st.session_state["page"] = "list"
+                st.rerun()
+
+
+
+pg = st.navigation([st.Page(page_1, title="공모전 정보"), st.Page(page_2, title="유저 정보")])
+pg.run()

--- a/PHP_Script_Manage/delete_crawl_data.php
+++ b/PHP_Script_Manage/delete_crawl_data.php
@@ -1,0 +1,34 @@
+<?php
+$servername = "localhost";  // 데이터베이스 서버
+$username = "opsw4";        // 사용자 이름
+$password = "opswteam4!";   // 비밀번호
+$dbname = "opsw4";          // 데이터베이스 이름
+
+// MySQL 연결
+$conn = new mysqli($servername, $username, $password, $dbname);
+
+// 연결 확인
+if ($conn->connect_error) {
+    die("연결 실패: " . $conn->connect_error);
+}
+
+$id = isset($_GET['id']) ? $_GET['id'] : null;
+
+// 데이터 유효성 확인
+if ($id) {
+    // 데이터 삭제 위한 SQL 쿼리 작성
+    $sql = "DELETE FROM crawl_data WHERE id = $id";
+    
+    // 쿼리 실행
+    if ($conn->query($sql) === TRUE) {
+        echo "레코드 삭제 완료. ";
+    } else {
+        echo "에러: " . $conn->error;
+    }
+} else {
+    echo "유효하지 않은 입력 데이터";
+}
+
+// 연결 종료
+$conn->close();
+?>

--- a/PHP_Script_Manage/delete_user_data_manage.php
+++ b/PHP_Script_Manage/delete_user_data_manage.php
@@ -1,0 +1,34 @@
+<?php
+$servername = "localhost";  // 데이터베이스 서버
+$username = "opsw4";        // 사용자 이름
+$password = "opswteam4!";   // 비밀번호
+$dbname = "opsw4";          // 데이터베이스 이름
+
+// MySQL 연결
+$conn = new mysqli($servername, $username, $password, $dbname);
+
+// 연결 확인
+if ($conn->connect_error) {
+    die("연결 실패: " . $conn->connect_error);
+}
+
+$id = isset($_GET['id']) ? $_GET['id'] : null;
+
+// 데이터 유효성 확인
+if ($id) {
+    // 데이터 삭제 위한 SQL 쿼리 작성
+    $sql = "DELETE FROM user_data WHERE id = $id";
+    
+    // 쿼리 실행
+    if ($conn->query($sql) === TRUE) {
+        echo "레코드 삭제 완료. ";
+    } else {
+        echo "에러: " . $conn->error;
+    }
+} else {
+    echo "유효하지 않은 입력 데이터";
+}
+
+// 연결 종료
+$conn->close();
+?>

--- a/PHP_Script_Manage/update_crawl_data.php
+++ b/PHP_Script_Manage/update_crawl_data.php
@@ -1,0 +1,37 @@
+<?php
+$servername = "localhost";  // 데이터베이스 서버
+$username = "opsw4";        // 사용자 이름
+$password = "opswteam4!";   // 비밀번호
+$dbname = "opsw4";          // 데이터베이스 이름
+
+// MySQL 연결
+$conn = new mysqli($servername, $username, $password, $dbname);
+
+// 연결 확인
+if ($conn->connect_error) {
+    die("연결 실패: " . $conn->connect_error);
+}
+
+$id = isset($_GET['id']) ? $_GET['id'] : null;
+$title = isset($_GET['title']) ? $_GET['title'] : null;
+$date = isset($_GET['date']) ? $_GET['date'] : null;
+$image = isset($_GET['image']) ? $_GET['image'] : null;
+
+// 데이터 유효성 확인
+if ($title && $date && $image) {
+    // 데이터 업데이트를 위한 SQL 쿼리 작성
+    $sql = "UPDATE crawl_data SET title='".$conn->real_escape_string($title)."', date='".$conn->real_escape_string($date)."', image='".$conn->real_escape_string($image)."' WHERE id = $id";
+    
+    // 쿼리 실행
+    if ($conn->query($sql) === TRUE) {
+        echo "레코드 수정 완료. ";
+    } else {
+        echo "에러: " . $conn->error;
+    }
+} else {
+    echo "유효하지 않은 입력 데이터";
+}
+
+// 연결 종료
+$conn->close();
+?>

--- a/PHP_Script_Manage/update_user_data_manage.php
+++ b/PHP_Script_Manage/update_user_data_manage.php
@@ -1,0 +1,37 @@
+<?php
+$servername = "localhost";  // 데이터베이스 서버
+$username = "opsw4";        // 사용자 이름
+$password = "opswteam4!";   // 비밀번호
+$dbname = "opsw4";          // 데이터베이스 이름
+
+// MySQL 연결
+$conn = new mysqli($servername, $username, $password, $dbname);
+
+// 연결 확인
+if ($conn->connect_error) {
+    die("연결 실패: " . $conn->connect_error);
+}
+
+$id = isset($_GET['id']) ? $_GET['id'] : null;
+$name = isset($_GET['name']) ? $_GET['name'] : null;
+$bio = isset($_GET['bio']) ? $_GET['bio'] : null;
+$tool = isset($_GET['tool']) ? $_GET['tool'] : null;
+
+// 데이터 유효성 확인
+if ($name && $bio && $tool) {
+    // 데이터 업데이트를 위한 SQL 쿼리 작성
+    $sql = "UPDATE user_data SET name='".$conn->real_escape_string($name)."', bio='".$conn->real_escape_string($bio)."', tool='".$conn->real_escape_string($tool)."' WHERE id = $id";
+    
+    // 쿼리 실행
+    if ($conn->query($sql) === TRUE) {
+        echo "레코드 수정 완료. ";
+    } else {
+        echo "에러: " . $conn->error;
+    }
+} else {
+    echo "유효하지 않은 입력 데이터";
+}
+
+// 연결 종료
+$conn->close();
+?>

--- a/Python_Script_Manage/select_from_db.py
+++ b/Python_Script_Manage/select_from_db.py
@@ -1,0 +1,19 @@
+import requests
+
+def get_user_data():
+    url = "http://opsw4.dothome.co.kr/select_from_user_data.php" # PHP API URL
+
+    try:
+        # GET 요청 보내기
+        response = requests.get(url)
+        
+        # 응답 상태 확인
+        if response.status_code == 200:
+            # JSON 데이터 파싱
+            data = response.json()
+        else:
+            print(f"요청 실패: {response.status_code}")
+    except requests.exceptions.RequestException as e:
+        print(f"요청 중 오류 발생: {e}")
+
+    return data


### PR DESCRIPTION
현재 데이터베이스에 등록된 정보 수정을 위한 관리자 대시보드 페이지를 개발했습니다.
화면 이동 및 상태는 st.session_state를 사용하여 관리했습니다!
st.rerun() 관련 적용이 잘 안된다고 하셨던 분들은 코드 참고하셔서 화면 이동 구현하시면 편하실 것 같습니다 !!
[./Front/manage/manage.py]

기본 화면은 아래와 같으며, 좌측 사이드바에서 공모전/유저 정보 수정/삭제 페이지로 이동 가능하며,
각 페이지의 타이틀에서 현재 데이터베이스에 있는 데이터의 개수를 확인하실 수 있습니다.
<img width="1436" alt="스크린샷 2024-12-08 오후 1 39 20" src="https://github.com/user-attachments/assets/b79838ee-1d15-4567-90e9-6e0ab7307e41">

수정 버튼을 클릭하면 해당 데이터를 수정/삭제할 수 있는 화면으로 전환되며,
실시간으로 데이터를 업데이트하며 업데이트된 정보를 확인하실 수 있습니다.
아래에 구현 영상 첨부합니다.

https://github.com/user-attachments/assets/1a9dcda7-62e6-49db-b310-d015f3f54499


위에서 말씀드린 session_state 및 rerun() 메소드는 다음과 같이 구현했습니다.
![무제 001](https://github.com/user-attachments/assets/8c950a38-42bd-44f2-afcd-67af042c4178)


작성한 PHP 스크립트 코드는 GET요청을 통해 전달된 파라미터로 데이터 수정/처리 작업을 진행했습니다!

아래 수정 정보는 다음과 같은 파라미터를 필요로 합니다: **id, title, date, image**
**공모전 정보 수정** - http://opsw4.dothome.co.kr/update_crawl_data.php

아래 수정 정보는 다음과 같은 파라미터를 필요로 합니다: **id, name, bio, tool**
**유저 정보 수정** - http://opsw4.dothome.co.kr/update_user_data_manage.php


아래 삭제 정보는 다음과 같은 파라미터를 필요로 합니다: **id**
**공모전 정보 삭제** - http://opsw4.dothome.co.kr/delete_crawl_data.php
**유저 정보 삭제** - http://opsw4.dothome.co.kr/delete_crawl_data.php

