### PR TITLE
#29 [Feat] 공모전 실제 모집 페이지 경로 추출

### DIFF
--- a/Crawling/Crawler.py
+++ b/Crawling/Crawler.py
@@ -4,41 +4,52 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import re
 import json
+import time
 
 def get_contest_data():
     driver = webdriver.Chrome()
-    url = 'https://www.onoffmix.com/event/main?s=공모전'
+    url = 'https://onoffmix.com/event/main/?c=105'
     driver.get(url)
-
-    try:
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li')))
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li article.event_area.event_main a div.event_info_area div.title_area')))
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li article.event_area.event_main a div.event_info_area div.event_info div.date')))
-    except Exception as e:
-        print("페이지 로딩 중 오류:", e)
-        driver.quit()
-        return []
-
-    # 실제 공모전 데이터 (포스터, 제목, 날짜)
-    images = driver.find_elements(By.CSS_SELECTOR, '#content > div > section.event_main_area > ul img')
-    titles = driver.find_elements(By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li article.event_area.event_main a div.event_info_area div.title_area')
-    dates = driver.find_elements(By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li article.event_area.event_main a div.event_info_area div.event_info div.date')
 
     contest_data = []
 
-    # 데이터 전처리
-    for img, title, date in zip(images, titles, dates):
-        img_url = img.get_attribute("src")
-        full_title = title.text
-        date_info = date.text.strip()  
-        if full_title.startswith("["):
-            full_title = re.sub(r'\[.*?\]', '', full_title).strip()
-        
-        contest_data.append({
-            "title": full_title,
-            "image": img_url,
-            "date": date_info
-        })
+    for page in range(1, 3):  # 크롤링할 페이지 범위 (1페이지부터 2페이지까지)
+        try:
+            # 공모전 리스트 로딩 대기
+            WebDriverWait(driver, 10).until(EC.presence_of_all_elements_located(
+                (By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li')))
+
+            # 데이터 요소 가져오기
+            images = driver.find_elements(By.CSS_SELECTOR, '#content > div > section.event_main_area > ul img')
+            titles = driver.find_elements(By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li article.event_area.event_main a div.event_info_area div.title_area')
+            dates = driver.find_elements(By.CSS_SELECTOR, '#content > div > section.event_main_area > ul > li article.event_area.event_main a div.event_info_area div.event_info div.date')
+
+            # 데이터 전처리
+            for img, title, date in zip(images, titles, dates):
+                img_url = img.get_attribute("src")
+                full_title = title.text
+                date_info = date.text.strip()
+                if full_title.startswith("["):
+                    full_title = re.sub(r'\[.*?\]', '', full_title).strip()
+
+                contest_data.append({
+                    "title": full_title,
+                    "image": img_url,
+                    "date": date_info,
+                })
+
+            # 다음 페이지로 이동
+            if page < 2:  # 마지막 페이지에서는 버튼을 클릭하지 않음
+                next_button = driver.find_element(By.CSS_SELECTOR, 
+                    "#content > div > section.event_main_area > div.pagination_wrap > div > a:nth-child(3)")
+                next_button.click()
+
+                # 페이지 로딩 대기
+                time.sleep(3)
+
+        except Exception as e:
+            print(f"{page}페이지 크롤링 중 오류:", e)
+            break
 
     driver.quit()
     return contest_data
@@ -46,7 +57,6 @@ def get_contest_data():
 # # 데이터 크롤링 결과
 # data = get_contest_data()
 
-# # json 형식으로 formatting
+# # JSON 형식으로 출력
 # crwaling_data = json.dumps(data, ensure_ascii=False, indent=4)
-
 # print(crwaling_data)

--- a/Crawling/LinkCrawler.py
+++ b/Crawling/LinkCrawler.py
@@ -4,49 +4,57 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from urllib.parse import urlparse, parse_qs
+import time
 
 def init_driver():
     driver = webdriver.Chrome()
     return driver
 
 # 이벤트 ID 리스트 추출
-def extract_event_ids(driver, main_url):
-    driver.get(main_url)
-    try:
-        # 이벤트 ID를 포함한 링크 추출
-        event_links = WebDriverWait(driver, 10).until(
-            EC.presence_of_all_elements_located(
-                (By.CSS_SELECTOR, "#content > div > section.event_main_area > ul li article.event_area.event_main a, "
-                                  "#content > div > section.event_main_area > ul li article.event_area.event_main.adv_list a")
+def extract_event_ids(driver, main_url, pages=2):
+    event_ids = []
+
+    for page in range(1, pages + 1):  # 1페이지부터 `pages`까지 크롤링
+        driver.get(f"{main_url}&page={page}")  # 페이지 쿼리 추가
+        try:
+            # 이벤트 ID를 포함한 링크 추출
+            event_links = WebDriverWait(driver, 10).until(
+                EC.presence_of_all_elements_located(
+                    (By.CSS_SELECTOR, "#content > div > section.event_main_area > ul li article.event_area.event_main a, "
+                                      "#content > div > section.event_main_area > ul li article.event_area.event_main.adv_list a")
+                )
             )
-        )
-        # URL 파싱을 통해 이벤트 ID 추출
-        event_ids = []
-        for link in event_links:
-            href = link.get_attribute("href")
-            parsed_url = urlparse(href)
-            if 'event' in parsed_url.path:
-                event_id = parsed_url.path.split('/')[-1]
-                event_ids.append(event_id)
-            elif 'url' in parse_qs(parsed_url.query):
-                # 쿼리 매개변수를 사용하여 이벤트 ID 추출
-                event_id = parse_qs(parsed_url.query)['url'][0].split('/')[-1]
-                event_ids.append(event_id)
-        return event_ids
-    except Exception as e:
-        print("이벤트 ID 추출 오류:", e)
-    return []
+            # URL 파싱을 통해 이벤트 ID 추출
+            for link in event_links:
+                href = link.get_attribute("href")
+                parsed_url = urlparse(href)
+                if 'event' in parsed_url.path:
+                    event_id = parsed_url.path.split('/')[-1]
+                    event_ids.append(event_id)
+                elif 'url' in parse_qs(parsed_url.query):
+                    # 쿼리 매개변수를 사용하여 이벤트 ID 추출
+                    event_id = parse_qs(parsed_url.query)['url'][0].split('/')[-1]
+                    event_ids.append(event_id)
+        except Exception as e:
+            print(f"{page}페이지 이벤트 ID 추출 오류:", e)
+        time.sleep(2)  # 페이지 로딩 대기
+    return event_ids
 
 # 모집 페이지 경로 추출
 def extract_recruitment_page(driver, event_url):
     driver.get(event_url)
     try:
-        # 참여 신청이 마감된 이벤트 추출
+        # 참여 신청이 마감된 이벤트 확인
         closed_message = driver.find_elements(By.CSS_SELECTOR, "#content > div.content_wrapping.wide_max_width_area > section.event_summary > div.right_area > form > div.btn_area > span")
         if closed_message and "참여 신청이 마감되었습니다" in closed_message[0].text:
             return "참여 신청 마감"
 
-        # 실제 모집 페이지 링크
+        # "신청하기" 버튼 처리
+        apply_button = driver.find_elements(By.CSS_SELECTOR, "#content > div.content_wrapping.wide_max_width_area > section.event_summary > div.right_area > form > div.btn_area > input")
+        if apply_button and "신청하기" in apply_button[0].get_attribute("value"):
+            return event_url  # 현재 페이지를 모집 페이지로 반환
+
+        # 모집 페이지 링크 추출
         recruitment_link = WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, "#content > div.content_wrapping.wide_max_width_area > section.event_summary > div.right_area > form > div.btn_area > a")
@@ -59,12 +67,12 @@ def extract_recruitment_page(driver, event_url):
 
 # 공모전 모집 페이지 경로를 반환하는 함수
 def get_link_data():
-    base_url = "https://www.onoffmix.com/event/main?s=공모전"
+    base_url = "https://onoffmix.com/event/main/?c=105"
     driver = init_driver()
 
     try:
-        # 1. 카테고리가 '공모전'인 모든 이벤트 ID 추출
-        event_ids = extract_event_ids(driver, base_url)
+        # 1. 카테고리가 '공모전'인 모든 이벤트 ID 추출 (2페이지 크롤링)
+        event_ids = extract_event_ids(driver, base_url, pages=2)
         recruitment_data = []
 
         if event_ids:
@@ -72,7 +80,7 @@ def get_link_data():
             for event_id in event_ids:
                 event_url = f"https://www.onoffmix.com/event/{event_id}"
                 recruitment_page = extract_recruitment_page(driver, event_url)
-                recruitment_data.append({"recruitment_page": recruitment_page})
+                recruitment_data.append({"event_id": event_id, "recruitment_page": recruitment_page})
 
             # JSON 형태로 결과 반환
             return json.dumps(recruitment_data, ensure_ascii=False, indent=4)

--- a/Crawling/LinkCrawler.py
+++ b/Crawling/LinkCrawler.py
@@ -1,0 +1,85 @@
+import json
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from urllib.parse import urlparse, parse_qs
+
+def init_driver():
+    driver = webdriver.Chrome()
+    return driver
+
+# 이벤트 ID 리스트 추출
+def extract_event_ids(driver, main_url):
+    driver.get(main_url)
+    try:
+        # 이벤트 ID를 포함한 링크 추출
+        event_links = WebDriverWait(driver, 10).until(
+            EC.presence_of_all_elements_located(
+                (By.CSS_SELECTOR, "#content > div > section.event_main_area > ul li article.event_area.event_main a, "
+                                  "#content > div > section.event_main_area > ul li article.event_area.event_main.adv_list a")
+            )
+        )
+        # URL 파싱을 통해 이벤트 ID 추출
+        event_ids = []
+        for link in event_links:
+            href = link.get_attribute("href")
+            parsed_url = urlparse(href)
+            if 'event' in parsed_url.path:
+                event_id = parsed_url.path.split('/')[-1]
+                event_ids.append(event_id)
+            elif 'url' in parse_qs(parsed_url.query):
+                # 쿼리 매개변수를 사용하여 이벤트 ID 추출
+                event_id = parse_qs(parsed_url.query)['url'][0].split('/')[-1]
+                event_ids.append(event_id)
+        return event_ids
+    except Exception as e:
+        print("이벤트 ID 추출 오류:", e)
+    return []
+
+# 모집 페이지 경로 추출
+def extract_recruitment_page(driver, event_url):
+    driver.get(event_url)
+    try:
+        # 참여 신청이 마감된 이벤트 추출
+        closed_message = driver.find_elements(By.CSS_SELECTOR, "#content > div.content_wrapping.wide_max_width_area > section.event_summary > div.right_area > form > div.btn_area > span")
+        if closed_message and "참여 신청이 마감되었습니다" in closed_message[0].text:
+            return "참여 신청 마감"
+
+        # 실제 모집 페이지 링크
+        recruitment_link = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, "#content > div.content_wrapping.wide_max_width_area > section.event_summary > div.right_area > form > div.btn_area > a")
+            )
+        )
+        return recruitment_link.get_attribute("href")
+    except Exception as e:
+        print(e)
+    return None
+
+# 공모전 모집 페이지 경로를 반환하는 함수
+def get_link_data():
+    base_url = "https://www.onoffmix.com/event/main?s=공모전"
+    driver = init_driver()
+
+    try:
+        # 1. 카테고리가 '공모전'인 모든 이벤트 ID 추출
+        event_ids = extract_event_ids(driver, base_url)
+        recruitment_data = []
+
+        if event_ids:
+            # 2. 각 이벤트 ID에 대해 실제 모집 페이지 경로 추출
+            for event_id in event_ids:
+                event_url = f"https://www.onoffmix.com/event/{event_id}"
+                recruitment_page = extract_recruitment_page(driver, event_url)
+                recruitment_data.append({"recruitment_page": recruitment_page})
+
+            # JSON 형태로 결과 반환
+            return json.dumps(recruitment_data, ensure_ascii=False, indent=4)
+        else:
+            return json.dumps({"error": "이벤트 ID를 추출할 수 없습니다."}, ensure_ascii=False, indent=4)
+    finally:
+        driver.quit()
+
+data = get_link_data()
+print(data)

--- a/Crawling/LinkCrawler.py
+++ b/Crawling/LinkCrawler.py
@@ -81,5 +81,5 @@ def get_link_data():
     finally:
         driver.quit()
 
-data = get_link_data()
-print(data)
+# data = get_link_data()
+# print(data)

--- a/PHP_Script/insert_into_crawl_data.php
+++ b/PHP_Script/insert_into_crawl_data.php
@@ -15,9 +15,10 @@ if ($conn->connect_error) {
 $title = isset($_GET['title']) ? $_GET['title'] : null;
 $date = isset($_GET['date']) ? $_GET['date'] : null;
 $image = isset($_GET['image']) ? $_GET['image'] : null;
+$page = isset($_GET['page']) ? $_GET['page'] : null;
 
 // 데이터 유효성 확인
-if ($title && $date && $image) {
+if ($title && $date && $image && $page) {
     // 압축 이미지를 저장할 폴더 및 파일명 설정
     $compressed_dir = __DIR__ . '/compressed';
     $image_name = basename($image);
@@ -78,8 +79,12 @@ if ($title && $date && $image) {
     echo "이미지 압축 완료. ";
     
     // 데이터베이스에 삽입할 SQL 쿼리 작성
-    $sql = "INSERT INTO crawl_data (title, date, image) VALUES ('" . $conn->real_escape_string($title) . "', 
-    '" . $conn->real_escape_string($date) . "', 'http://opsw4.dothome.co.kr/compressed/" . $conn->real_escape_string($image_name) . "')";
+    $sql = "INSERT INTO crawl_data (title, date, image, page) VALUES (
+        '" . $conn->real_escape_string($title) . "', 
+        '" . $conn->real_escape_string($date) . "', 
+        'http://opsw4.dothome.co.kr/compressed/" . $conn->real_escape_string($image_name) . "', 
+        '" . $conn->real_escape_string($page) . "'
+    )";
     
     // 쿼리 실행
     if ($conn->query($sql) === TRUE) {

--- a/PHP_Script/select_from_crawl_data.php
+++ b/PHP_Script/select_from_crawl_data.php
@@ -29,7 +29,8 @@ if ($result->num_rows > 0) {
             "id" => $row["id"],
             "title" => $row["title"],
             "date" => $row["date"],
-            "image" => $row["image"]
+            "image" => $row["image"],
+            "page" => $row["page"]
         ];
     }
     echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);

--- a/Python_Script/insert_to_db.py
+++ b/Python_Script/insert_to_db.py
@@ -1,19 +1,33 @@
 import requests
 import sys
 import os
+import json
+
 # 현재 파일의 상위 디렉토리를 경로에 추가
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 from Crawling.Crawler import get_contest_data
+from Crawling.LinkCrawler import get_link_data
 
 # 요청을 보낼 URL
 url = "http://opsw4.dothome.co.kr/insert_into_crawl_data.php"
 
-for i in get_contest_data():
-    params = { # GET 요청의 쿼리 파라미터
-        # 데이터 포맷
-        "title": i['title'],
-        "date": i['date'],
-        "image": i['image'],
+# 공모전 데이터 가져오기
+contest_data = get_contest_data()
+
+# 모집 페이지 데이터 가져오기
+link_data = json.loads(get_link_data())  # JSON 문자열을 Python 객체로 변환
+
+# 모집 페이지 데이터를 `contest_data`에 병합
+for idx, contest in enumerate(contest_data):
+    # 모집 페이지가 존재하면 병합, 없으면 기본값 설정
+    contest["page"] = link_data[idx]["recruitment_page"] if idx < len(link_data) else "N/A"
+
+    # GET 요청의 쿼리 파라미터
+    params = {
+        "title": contest['title'],
+        "date": contest['date'],
+        "image": contest['image'],
+        "page": contest['page'],  # 추가된 page 데이터
     }
 
     # GET 요청 보내기


### PR DESCRIPTION
### 수정사항

### 1. 각 공모전의 실제 모집 페이지 경로를 추출 (외부 접수 링크로 가는 버튼의 경로를 추출)

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/97fa7e21-68b7-4851-9e2e-02199cf9b008">

### 2. 모집 경로 데이터 추가로 인한 데이터베이스 테이블 수정, php 파일 업로드
<img width="1415" alt="스크린샷 2024-12-09 오후 3 33 19" src="https://github.com/user-attachments/assets/2e5b31dc-1efc-4379-bbfa-8148169e8b2c">

### 3. insert_to_db.py 파이썬 스크립트에서 GET 요청 쿼리 파라미터에 page 데이터 추가
<img width="374" alt="스크린샷 2024-12-09 오후 3 37 24" src="https://github.com/user-attachments/assets/3219332e-a11f-4d8f-aeac-955f85e6fc6a">

<br>
<br>

### 4. 크롤링 로직 수정
url 쿼리 파라미터에 '공모전' 키워드가 포함된 단순 검색보다 플랫폼 내에서 카테고리를 정한 이후에 크롤링
<img width="650" alt="image" src="https://github.com/user-attachments/assets/6a70ea30-fab8-4216-86bf-5d4f49b2e791">

### >>>>

<img width="650" alt="image" src="https://github.com/user-attachments/assets/b4d3b05b-a26c-41fb-aa27-50c1e0ac910b">

https://onoffmix.com/event/main?s=공모전 -> https://onoffmix.com/event/main/?c=105

**제목에 공모전이 포함되어야 크롤링 대상이 되던 문제점 개선**